### PR TITLE
fix: stop overwriting tutor plugin from deploy workflow (dev 502 hotfix)

### DIFF
--- a/.github/workflows/deeprun-deploy.yml
+++ b/.github/workflows/deeprun-deploy.yml
@@ -219,10 +219,6 @@ jobs:
             echo "=== Cleaning up unused images ==="
             docker image prune -af --filter "until=1h" || true
 
-            echo "=== Updating Tutor plugin ==="
-            PLUGIN_ROOT=$(tutor plugins printroot)
-            curl -sL "https://raw.githubusercontent.com/deeprun-academy/tutor-config/main/plugins/deeprun.py" -o "$PLUGIN_ROOT/deeprun.py"
-
             echo "=== Pulling image ==="
             docker pull ghcr.io/deeprun-academy/openedx:dev
 
@@ -231,7 +227,7 @@ jobs:
               --set DOCKER_IMAGE_OPENEDX=ghcr.io/deeprun-academy/openedx:dev
 
             echo "=== Restarting ==="
-            docker compose -f ~/.local/share/tutor/env/local/docker-compose.yml -f ~/.local/share/tutor/env/local/docker-compose.prod.yml --project-name tutor_local up --remove-orphans -d
+            docker compose -f ~/.local/share/tutor/env/local/docker-compose.yml -f ~/.local/share/tutor/env/local/docker-compose.prod.yml --project-name tutor_local up -d lms cms lms-worker cms-worker
 
             echo "=== Running migrations ==="
             tutor local run lms ./manage.py lms migrate --noinput
@@ -267,10 +263,6 @@ jobs:
             echo "=== Cleaning up unused images ==="
             docker image prune -af --filter "until=1h" || true
 
-            echo "=== Updating Tutor plugin ==="
-            PLUGIN_ROOT=$(tutor plugins printroot)
-            curl -sL "https://raw.githubusercontent.com/deeprun-academy/tutor-config/main/plugins/deeprun.py" -o "$PLUGIN_ROOT/deeprun.py"
-
             echo "=== Pulling image ==="
             docker pull ghcr.io/deeprun-academy/openedx:uat
 
@@ -279,7 +271,7 @@ jobs:
               --set DOCKER_IMAGE_OPENEDX=ghcr.io/deeprun-academy/openedx:uat
 
             echo "=== Restarting ==="
-            docker compose -f ~/.local/share/tutor/env/local/docker-compose.yml -f ~/.local/share/tutor/env/local/docker-compose.prod.yml --project-name tutor_local up --remove-orphans -d
+            docker compose -f ~/.local/share/tutor/env/local/docker-compose.yml -f ~/.local/share/tutor/env/local/docker-compose.prod.yml --project-name tutor_local up -d lms cms lms-worker cms-worker
 
             echo "=== Running migrations ==="
             tutor local run lms ./manage.py lms migrate --noinput
@@ -315,10 +307,6 @@ jobs:
             echo "=== Cleaning up unused images ==="
             docker image prune -af --filter "until=1h" || true
 
-            echo "=== Updating Tutor plugin ==="
-            PLUGIN_ROOT=$(tutor plugins printroot)
-            curl -sL "https://raw.githubusercontent.com/deeprun-academy/tutor-config/main/plugins/deeprun.py" -o "$PLUGIN_ROOT/deeprun.py"
-
             echo "=== Pulling image ==="
             docker pull ghcr.io/deeprun-academy/openedx:prod
 
@@ -327,7 +315,7 @@ jobs:
               --set DOCKER_IMAGE_OPENEDX=ghcr.io/deeprun-academy/openedx:prod
 
             echo "=== Restarting ==="
-            docker compose -f ~/.local/share/tutor/env/local/docker-compose.yml -f ~/.local/share/tutor/env/local/docker-compose.prod.yml --project-name tutor_local up --remove-orphans -d
+            docker compose -f ~/.local/share/tutor/env/local/docker-compose.yml -f ~/.local/share/tutor/env/local/docker-compose.prod.yml --project-name tutor_local up -d lms cms lms-worker cms-worker
 
             echo "=== Running migrations ==="
             tutor local run lms ./manage.py lms migrate --noinput


### PR DESCRIPTION
## Summary
- **Hotfix:** dev site 502 caused by this deploy workflow overwriting the tutor plugin with `404: Not Found`.
- Remove the `curl` block that downloads `tutor-config/main/plugins/deeprun.py` from a public raw GitHub URL. tutor-config is now a private repo, so unauthenticated curl returned a 404 body which was saved as the plugin → `illegal target for annotation (deeprun.py, line 1)` → docker-compose regenerated without plugin services → frontend/preflop/thumbnail containers killed by `--remove-orphans`.
- Replace `docker compose up --remove-orphans -d` with an explicit service list (`lms cms lms-worker cms-worker`) so this workflow only restarts the Django containers it actually owns.

## Root cause chain

```
curl -sL "https://raw.githubusercontent.com/deeprun-academy/tutor-config/main/plugins/deeprun.py"
     ↓ (tutor-config went private)
"404: Not Found" (7 chars, exit 0, no -f flag → silent failure)
     ↓
tutor config save → plugin fails to parse → silently skipped
     ↓
docker-compose regenerated WITHOUT frontend/preflop/thumbnail services
     ↓
docker compose up --remove-orphans → kills the 3 "orphaned" containers
     ↓
Caddy can't dial `frontend` / `preflop-api` → 502 Bad Gateway
```

## Fix rationale

**Remove the curl, don't fix it.** Plugin management belongs in tutor-config's own `deploy-config.yml` workflow — it copies the plugin from the server's local clone of tutor-config (no cross-repo curl, no private-repo auth problem). openedx-platform's job is to build and ship the openedx image, nothing more.

**Scope docker compose up to specific services.** `--remove-orphans` across the whole compose is too aggressive — it kills services this workflow doesn't own. Explicit `up -d lms cms lms-worker cms-worker` only restarts what we just updated.

## Pre-merge checklist
- [x] YAML validates
- [x] No remaining `curl` or `--remove-orphans` in the workflow
- [x] Applied the same fix to all 3 jobs: `deploy-dev`, `deploy-uat`, `deploy-prod`

## Test plan + recovery steps
- [ ] Merge → `deploy-dev` triggers → pulls new openedx image → recreates LMS/CMS/workers only (no plugin overwrite, no orphan kill)
- [ ] **Then:** go to tutor-config Actions → latest `Deploy Tutor Config (Dev)` run → Re-run all jobs → restores the plugin + regenerates docker-compose with frontend/preflop/thumbnail → `tutor local start -d` brings them back
- [ ] External smoke: `https://dev.deeprun.academy/` → 302 (healthy), `https://api.dev.deeprun.academy/health` → 200
- [ ] Container status on dev: frontend, preflop-api, thumbnail-worker all Up
- [ ] Studio + LMS unaffected throughout

## Incident trace
- tutor-config flipped to private recently
- openedx-platform PR #22 merged (env-scoped secrets) → deploy-dev ran → hit the bug above → 502

## Related repositories
- `tutor-config` remains the single source of truth for the Tutor plugin. Its own `deploy-config.yml` copies `plugins/deeprun.py` from the local checkout on the server — no curl required.
