### PR TITLE
fix(content_staging): idempotent migration for _source_usage_key column

### DIFF
--- a/openedx/core/djangoapps/content_staging/migrations/0006_rename_source_usage_key.py
+++ b/openedx/core/djangoapps/content_staging/migrations/0006_rename_source_usage_key.py
@@ -1,0 +1,54 @@
+"""
+Rename content_staging_userclipboard._source_usage_key -> source_usage_key.
+
+The model declares `source_usage_key` but historical DBs carry the legacy
+`_source_usage_key` column, so Studio raises OperationalError (1054) when
+rendering the course outline. This migration is idempotent: it only renames
+the column when the legacy name still exists, so environments that were
+patched out-of-band (e.g. dev via manual ALTER) remain safe.
+"""
+from django.db import migrations
+
+
+FORWARD_SQL = """
+SET @has_legacy := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'content_staging_userclipboard'
+      AND COLUMN_NAME = '_source_usage_key'
+);
+SET @stmt := IF(
+    @has_legacy > 0,
+    'ALTER TABLE content_staging_userclipboard '
+    'CHANGE `_source_usage_key` `source_usage_key` varchar(255) NOT NULL',
+    'DO 0'
+);
+PREPARE s FROM @stmt; EXECUTE s; DEALLOCATE PREPARE s;
+"""
+
+REVERSE_SQL = """
+SET @has_new := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'content_staging_userclipboard'
+      AND COLUMN_NAME = 'source_usage_key'
+);
+SET @stmt := IF(
+    @has_new > 0,
+    'ALTER TABLE content_staging_userclipboard '
+    'CHANGE `source_usage_key` `_source_usage_key` varchar(255) NOT NULL',
+    'DO 0'
+);
+PREPARE s FROM @stmt; EXECUTE s; DEALLOCATE PREPARE s;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('content_staging', '0005_stagedcontent_version_num'),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql=FORWARD_SQL, reverse_sql=REVERSE_SQL),
+    ]


### PR DESCRIPTION
## Summary

Adds `content_staging/migrations/0006_rename_source_usage_key.py` — an idempotent migration that renames the legacy `_source_usage_key` column to `source_usage_key` on `content_staging_userclipboard`.

## Why

The `_UserClipboard` model (`openedx/core/djangoapps/content_staging/models.py:111`) declares `source_usage_key`, but historical DBs carry the legacy `_source_usage_key` column. Studio hits this on every course outline load via `get_user_clipboard_json` → `OperationalError (1054) Unknown column 'content_staging_userclipboard.source_usage_key'` → 500.

Observed on UAT `2026-04-19` at `GET /course/course-v1:grant-gradner+course-sqp01y+2026_Q2`. Dev was patched out-of-band previously with a manual `ALTER TABLE`; this migration formalises the fix and covers UAT/prod going forward.

## Approach

`RunSQL` + MySQL `PREPARE`/`EXECUTE` guarded by an `information_schema.COLUMNS` lookup. Runs `ALTER TABLE` only when `_source_usage_key` still exists; otherwise `DO 0` (no-op). Reverse direction is symmetric.

This makes the migration safe to apply on any environment regardless of current column name:
- **dev** (column already `source_usage_key`): no-op, migration marked applied
- **UAT / prod** (column still `_source_usage_key`): rename runs, Studio unblocked

## Test plan

- [ ] Merge to `dev` → dev redeploys → `tutor local launch --non-interactive` runs migrations → dev Studio still loads course outline (migration no-ops because column is already renamed).
- [ ] Promote `dev` → `uat` → UAT redeploys → migration renames column → `GET /course/course-v1:grant-gradner+course-sqp01y+2026_Q2` returns 200 and Video Uploads tab loads.
- [ ] Verify column state on each env:
  ```bash
  ssh ubuntu@<server> "docker exec tutor_local-mysql-1 mysql -u root -p\$(source ~/.tutor-venv/bin/activate && tutor config printvalue MYSQL_ROOT_PASSWORD) -e 'SHOW COLUMNS FROM openedx.content_staging_userclipboard LIKE \"%source_usage_key%\";'"
  ```
  Expected post-migration: `source_usage_key` on both.
- [ ] Confirm `django_migrations` row for `content_staging.0006_rename_source_usage_key` exists on both dev and UAT after deploy.