### PR TITLE
Promote dev → uat: idempotent migration for _source_usage_key

### DIFF
--- a/openedx/core/djangoapps/content_staging/migrations/0006_rename_source_usage_key.py
+++ b/openedx/core/djangoapps/content_staging/migrations/0006_rename_source_usage_key.py
@@ -1,0 +1,54 @@
+"""
+Rename content_staging_userclipboard._source_usage_key -> source_usage_key.
+
+The model declares `source_usage_key` but historical DBs carry the legacy
+`_source_usage_key` column, so Studio raises OperationalError (1054) when
+rendering the course outline. This migration is idempotent: it only renames
+the column when the legacy name still exists, so environments that were
+patched out-of-band (e.g. dev via manual ALTER) remain safe.
+"""
+from django.db import migrations
+
+
+FORWARD_SQL = """
+SET @has_legacy := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'content_staging_userclipboard'
+      AND COLUMN_NAME = '_source_usage_key'
+);
+SET @stmt := IF(
+    @has_legacy > 0,
+    'ALTER TABLE content_staging_userclipboard '
+    'CHANGE `_source_usage_key` `source_usage_key` varchar(255) NOT NULL',
+    'DO 0'
+);
+PREPARE s FROM @stmt; EXECUTE s; DEALLOCATE PREPARE s;
+"""
+
+REVERSE_SQL = """
+SET @has_new := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'content_staging_userclipboard'
+      AND COLUMN_NAME = 'source_usage_key'
+);
+SET @stmt := IF(
+    @has_new > 0,
+    'ALTER TABLE content_staging_userclipboard '
+    'CHANGE `source_usage_key` `_source_usage_key` varchar(255) NOT NULL',
+    'DO 0'
+);
+PREPARE s FROM @stmt; EXECUTE s; DEALLOCATE PREPARE s;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('content_staging', '0005_stagedcontent_version_num'),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql=FORWARD_SQL, reverse_sql=REVERSE_SQL),
+    ]


### PR DESCRIPTION
## Summary

Promotes dev to UAT to ship #25: the idempotent `content_staging` migration that renames `_source_usage_key` → `source_usage_key` on `content_staging_userclipboard`.

## Why now

UAT's `content_staging_userclipboard` still has the legacy `_source_usage_key` column, so every Studio course outline load 500s with `OperationalError (1054)`. Dev has already verified the migration is a clean no-op on an already-renamed DB; UAT will run the real rename on first `tutor local launch --non-interactive` after deploy.

Reference: #25 (merged to dev), and tutor-config CLAUDE.md Fix 4.

## Commits

- `a57a1dc6` feat: add migration to rename legacy column _source_usage_key to source_usage_key
- `0ce92ad8` Merge pull request #25

## Test plan

- [ ] Merge to `uat` → CI builds `ghcr.io/deeprun-academy/openedx:uat` → UAT redeploys.
- [ ] `tutor local launch --non-interactive` applies migration `content_staging.0006_rename_source_usage_key`.
- [ ] Verify column rename on UAT:
  ```bash
  ssh -i ~/Desktop/deeprun.pem ubuntu@18.139.134.239 \
    "docker exec tutor_local-mysql-1 mysql -u root -p\$(source ~/.tutor-venv/bin/activate && tutor config printvalue MYSQL_ROOT_PASSWORD) \
     -e 'SHOW COLUMNS FROM openedx.content_staging_userclipboard LIKE \"%source_usage_key%\";'"
  # Expected: source_usage_key (not _source_usage_key)
  ```
- [ ] Confirm `django_migrations` row exists:
  ```sql
  SELECT app, name, applied FROM django_migrations
  WHERE app='content_staging' AND name='0006_rename_source_usage_key';
  ```
- [ ] Studio `GET /course/course-v1:grant-gradner+course-sqp01y+2026_Q2` returns 200.
- [ ] Video Uploads tab loads and video upload works end-to-end.