### PR TITLE
fix(video_pipeline): enable VideoUploadsEnabledByDefault platform-wide

### DIFF
--- a/openedx/core/djangoapps/video_pipeline/migrations/0004_enable_video_uploads_by_default.py
+++ b/openedx/core/djangoapps/video_pipeline/migrations/0004_enable_video_uploads_by_default.py
@@ -1,0 +1,40 @@
+"""
+Ensure VideoUploadsEnabledByDefault is enabled platform-wide.
+
+Studio hides the "Video Uploads" link in the Content menu unless
+``context_course.video_pipeline_configured`` is True, which requires the
+``VideoUploadsEnabledByDefault`` ConfigurationModel to be enabled with
+``enabled_for_all_courses=True``. Fresh environments start with the flag
+disabled, so Studio silently loses the menu until an operator enables it.
+
+This data migration inserts an enabled row if the current latest row is
+missing or disabled. ConfigurationModel treats the newest row as
+authoritative, so appending a row is always safe — the check merely avoids
+redundant inserts on environments that are already enabled (e.g. dev).
+"""
+from django.db import migrations
+
+
+def enable_video_uploads_by_default(apps, schema_editor):
+    Model = apps.get_model("video_pipeline", "VideoUploadsEnabledByDefault")
+    latest = Model.objects.order_by("-change_date").first()
+    if latest is None or not (latest.enabled and latest.enabled_for_all_courses):
+        Model.objects.create(enabled=True, enabled_for_all_courses=True)
+
+
+def noop(apps, schema_editor):
+    # Reverse intentionally does nothing: rolling back should not disable the
+    # flag on environments that rely on it. Operators can flip the flag via
+    # Django admin if they really need to revert.
+    return
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("video_pipeline", "0003_coursevideouploadsenabledbydefault_videouploadsenabledbydefault"),
+    ]
+
+    operations = [
+        migrations.RunPython(enable_video_uploads_by_default, noop),
+    ]


### PR DESCRIPTION
## Summary

Adds `video_pipeline/migrations/0004_enable_video_uploads_by_default.py` — an idempotent RunPython data migration that ensures `VideoUploadsEnabledByDefault` is turned on platform-wide on any environment that doesn't already have it.

Hotfix branched from `uat` (will rebase to `dev` after UAT verifies).

## Why

Studio renders the **Content → Video Uploads** menu only when `context_course.video_pipeline_configured` is True (`cms/templates/widgets/header.html:141`). That property requires `VideoUploadsEnabledByDefault.feature_enabled(course_id)` → which requires the current config row to have both `enabled=True` and `enabled_for_all_courses=True` (`openedx/core/djangoapps/video_pipeline/models.py:73`).

Observed on UAT `2026-04-19`:

```
UAT VideoUploadsEnabledByDefault.current(): VideoUploadsEnabledByDefault: enabled False
UAT feature_enabled for course: False
course.video_upload_pipeline: {}
course.video_pipeline_configured: False
```

Dev had been enabled manually via Django admin, UAT never was, and prod will hit the same trap on first deploy.

## Approach

`ConfigurationModel` uses the newest row as authoritative, so enabling the flag is just an `objects.create`. To avoid redundant inserts, the migration reads the latest row and only creates a new one when `not (latest.enabled and latest.enabled_for_all_courses)`.

- **dev** (already `enabled=True`, `enabled_for_all_courses=True`): RunPython no-ops, migration marked applied.
- **UAT** (`enabled=False`): inserts `enabled=True, enabled_for_all_courses=True` → menu appears.
- **prod** (fresh, disabled by default): same behaviour as UAT on first deploy → menu ready out of the box.

Reverse is a no-op so rollbacks don't accidentally disable the flag on environments that depend on it.

## Test plan

- [ ] Merge to `uat` → CI builds `ghcr.io/deeprun-academy/openedx:uat` → UAT redeploys → `tutor local launch --non-interactive` runs migration `video_pipeline.0004_enable_video_uploads_by_default`.
- [ ] Verify flag state on UAT:
  ```bash
  ssh -i ~/Desktop/deeprun.pem ubuntu@18.139.134.239 \
    "source ~/.tutor-venv/bin/activate && tutor local run cms ./manage.py cms shell -c \"
  from openedx.core.djangoapps.video_pipeline.models import VideoUploadsEnabledByDefault
  c = VideoUploadsEnabledByDefault.current()
  print('enabled=', c.enabled, 'enabled_for_all_courses=', c.enabled_for_all_courses)
  \""
  # Expected: enabled= True enabled_for_all_courses= True
  ```
- [ ] Confirm `django_migrations` row:
  ```sql
  SELECT app, name, applied FROM django_migrations
  WHERE app='video_pipeline' AND name='0004_enable_video_uploads_by_default';
  ```
- [ ] Studio course outline shows **Content → Video Uploads** link on `course-v1:grant-gradner+course-sqp01y+2026_Q2`.
- [ ] Upload a test video on UAT end-to-end (S3 upload, processing, playback).

## Follow-ups

- After UAT verifies, rebase this branch onto `dev` so prod promotion carries the migration forward (dev will no-op, so zero risk).