### PR TITLE
fix(video_pipeline): rechain enable_video_uploads_by_default migration as 0008

### DIFF
--- a/openedx/core/djangoapps/video_pipeline/migrations/0008_enable_video_uploads_by_default.py
+++ b/openedx/core/djangoapps/video_pipeline/migrations/0008_enable_video_uploads_by_default.py
@@ -32,7 +32,7 @@ def noop(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("video_pipeline", "0003_coursevideouploadsenabledbydefault_videouploadsenabledbydefault"),
+        ("video_pipeline", "0007_delete_videopipelineintegration"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary

Follow-up to #27. Renames the idempotent data migration from `0004_enable_video_uploads_by_default.py` to `0008_enable_video_uploads_by_default.py` and re-anchors its dependency on `0007_delete_videopipelineintegration`.

## Why the first PR didn't work

After merging #27 and redeploying UAT, `VideoUploadsEnabledByDefault.current()` is still `enabled=False, enabled_for_all_courses=False`. Root cause: the fork's `video_pipeline` migrations chain is `0001 → 0002 → 0003 → 0004_vempipelineintegration → 0005 → 0006 → 0007_delete_videopipelineintegration`. Adding a second `0004_*` node with `dependencies = [("video_pipeline", "0003_...")]` creates a conflicting branch in the migration graph — Django honours the upstream `0004_vempipelineintegration` leaf and never applies our new node, leaving the flag untouched.

Verified on UAT after the #27 deploy:

```
enabled= False enabled_for_all_courses= False
feature_enabled= False
video_pipeline_configured= False
```

and `django_migrations` shows `0004_vempipelineintegration`…`0007_delete_videopipelineintegration` applied, but no row for our migration.

## Change

- Rename `0004_enable_video_uploads_by_default.py` → `0008_enable_video_uploads_by_default.py`.
- Update `dependencies` to `[("video_pipeline", "0007_delete_videopipelineintegration")]`.

Now 0008 is the single leaf of the graph. Logic is otherwise unchanged: idempotent RunPython that only inserts an enabled row when the current latest row isn't already fully enabled.

## Test plan

- [ ] Merge to `uat` → UAT redeploys → `tutor local launch --non-interactive` applies `video_pipeline.0008_enable_video_uploads_by_default`.
- [ ] Verify:
  ```bash
  ssh -i ~/Desktop/deeprun.pem ubuntu@18.139.134.239 \
    "source ~/.tutor-venv/bin/activate && tutor local run cms ./manage.py cms shell -c \"
  from openedx.core.djangoapps.video_pipeline.models import VideoUploadsEnabledByDefault
  c = VideoUploadsEnabledByDefault.current()
  print('enabled=', c.enabled, 'enabled_for_all_courses=', c.enabled_for_all_courses)
  \""
  # Expected: enabled= True enabled_for_all_courses= True
  ```
- [ ] `django_migrations` contains `video_pipeline.0008_enable_video_uploads_by_default`.
- [ ] Studio **Content → Video Uploads** link is visible on `course-v1:grant-gradner+course-sqp01y+2026_Q2`.

## Follow-ups

- Rebase to `dev` after UAT verifies. Dev already has both flags enabled, so the RunPython no-ops and the migration row is recorded.