### PR TITLE
fix(video upload): use boto3 credential chain in storage_service_bucket (closes #30)

### DIFF
--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -870,6 +870,14 @@ def videos_post(course, request):
 def storage_service_bucket():
     """
     Returns an S3 bucket for video upload.
+
+    Credentials resolution:
+      * Devstack path keeps legacy behaviour (explicit settings incl. security token).
+      * Production path prefers explicit `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` when set,
+        and otherwise falls back to the boto3 credential chain (env vars, shared config,
+        EC2 IAM role via IMDSv2). The legacy `boto` library used here cannot speak IMDSv2
+        on its own, which broke Studio video uploads on EC2 instances running with the
+        AWS-default `HttpTokens=required` — see deeprun-academy/openedx-platform#30.
     """
     if ENABLE_DEVSTACK_VIDEO_UPLOADS.is_enabled():
         params = {
@@ -879,10 +887,30 @@ def storage_service_bucket():
 
         }
     else:
+        access_key = settings.AWS_ACCESS_KEY_ID
+        secret_key = settings.AWS_SECRET_ACCESS_KEY
+        security_token = None
+        if not access_key or not secret_key:
+            # Fall back to the boto3 credential chain (env, shared config, IAM role via IMDSv2).
+            import boto3
+            frozen = None
+            creds = boto3.Session().get_credentials()
+            if creds is not None:
+                frozen = creds.get_frozen_credentials()
+            if frozen is None or not frozen.access_key or not frozen.secret_key:
+                raise RuntimeError(
+                    "No AWS credentials available for video upload bucket: set "
+                    "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or attach an IAM instance role."
+                )
+            access_key = frozen.access_key
+            secret_key = frozen.secret_key
+            security_token = frozen.token
         params = {
-            'aws_access_key_id': settings.AWS_ACCESS_KEY_ID,
-            'aws_secret_access_key': settings.AWS_SECRET_ACCESS_KEY
+            'aws_access_key_id': access_key,
+            'aws_secret_access_key': secret_key,
         }
+        if security_token:
+            params['security_token'] = security_token
 
     conn = S3Connection(**params)
 

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -1666,6 +1666,44 @@ class GetStorageBucketTestCase(TestCase):
         self.assertIn("https://vem_test_bucket.s3.amazonaws.com:443/test_root/", upload_url)
         self.assertIn(edx_video_id, upload_url)
 
+    @override_settings(AWS_ACCESS_KEY_ID=None, AWS_SECRET_ACCESS_KEY=None)
+    @override_settings(VIDEO_UPLOAD_PIPELINE={
+        "VEM_S3_BUCKET": "vem_test_bucket", "BUCKET": "test_bucket", "ROOT_PATH": "test_root"
+    })
+    def test_storage_bucket_falls_back_to_boto3_credentials(self):
+        """When explicit AWS keys are unset (IAM role deploy), credentials come from
+        the boto3 chain (env vars, shared config, EC2 IMDSv2 instance role)."""
+        frozen = Mock(access_key='boto3_key', secret_key='boto3_secret', token='boto3_token')
+        session = Mock()
+        session.get_credentials.return_value.get_frozen_credentials.return_value = frozen
+
+        with patch('boto3.Session', return_value=session) as session_cls, \
+                patch(
+                    'cms.djangoapps.contentstore.video_storage_handlers.S3Connection'
+                ) as s3_conn_cls:
+            storage_service_bucket()
+
+        session_cls.assert_called_once_with()
+        s3_conn_cls.assert_called_once_with(
+            aws_access_key_id='boto3_key',
+            aws_secret_access_key='boto3_secret',
+            security_token='boto3_token',
+        )
+
+    @override_settings(AWS_ACCESS_KEY_ID=None, AWS_SECRET_ACCESS_KEY=None)
+    @override_settings(VIDEO_UPLOAD_PIPELINE={
+        "VEM_S3_BUCKET": "vem_test_bucket", "BUCKET": "test_bucket", "ROOT_PATH": "test_root"
+    })
+    def test_storage_bucket_raises_when_no_credentials_available(self):
+        """Fail loudly rather than passing None into boto when the IAM role is missing."""
+        session = Mock()
+        session.get_credentials.return_value = None
+
+        with patch('boto3.Session', return_value=session), \
+                patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection'):
+            with self.assertRaisesRegex(RuntimeError, 'No AWS credentials available'):
+                storage_service_bucket()
+
 
 class CourseYoutubeEdxVideoIds(ModuleStoreTestCase):
     """


### PR DESCRIPTION
## Summary

Patches `cms/djangoapps/contentstore/video_storage_handlers.py:storage_service_bucket()` so that when the explicit `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` settings are unset (IAM-role deploys), credentials are fetched via `boto3.Session().get_credentials()` and handed to the legacy `boto` `S3Connection` as explicit strings.

Closes #30.

## Why

The handler uses the legacy `boto` library, which only speaks IMDSv1. EC2 instances launched with the AWS-default `HttpTokens=required` refuse IMDSv1 with HTTP 401, so `boto` errors out with `NoAuthHandlerFound` and Studio video upload returns 500.

Observed on UAT 2026-04-19 after `tutor-config@a9e299b` switched the deploy to IAM-role-based credentials:

```
File "/openedx/edx-platform/cms/djangoapps/contentstore/video_storage_handlers.py", line 887, in storage_service_bucket
    conn = S3Connection(**params)
File "/openedx/venv/lib/python3.11/site-packages/boto/auth.py", line 1018, in get_auth_handler
    raise boto.exception.NoAuthHandlerFound(
boto.exception.NoAuthHandlerFound: No handler was ready to authenticate.
  1 handlers were checked. ['HmacAuthV1Handler'] Check your credentials
```

UAT was unblocked manually by relaxing `HttpTokens` to `optional` (allowing IMDSv1 fallback). Prod should not need that workaround. With this patch prod can keep AWS's secure default and the IAM role still works.

## Change

```python
if not access_key or not secret_key:
    import boto3
    creds = boto3.Session().get_credentials()
    if creds is None or not creds.get_frozen_credentials().access_key:
        raise RuntimeError("No AWS credentials available for video upload bucket: ...")
    frozen = creds.get_frozen_credentials()
    access_key, secret_key, security_token = frozen.access_key, frozen.secret_key, frozen.token
```

- Devstack branch (`ENABLE_DEVSTACK_VIDEO_UPLOADS`) is untouched — still uses explicit settings incl. `AWS_SECURITY_TOKEN`.
- Loud `RuntimeError` on missing credentials so failures are diagnosable instead of surfacing as a generic boto error.

## Tests

Two new tests in `views/tests/test_videos.py:GetStorageBucketTestCase`:
- `test_storage_bucket_falls_back_to_boto3_credentials` — asserts boto3-resolved key/secret/token are passed to `S3Connection` when explicit settings are `None`.
- `test_storage_bucket_raises_when_no_credentials_available` — asserts the `RuntimeError` path when neither explicit settings nor `boto3.Session()` have creds.

The existing `test_storage_bucket` covers the explicit-settings happy path; together they exercise both branches of the new logic.

## Test plan

- [ ] CI green (unit tests).
- [ ] Merge → dev redeploys via `tutor local launch` → image rebuilt with patch.
- [ ] On dev (which currently runs with explicit AWS keys), Studio video upload still works as before — explicit-settings branch unchanged.
- [ ] Promote `dev → uat` → verify on UAT the upload still works after the manual IMDS workaround is reverted (`HttpTokens=required`):
  ```bash
  aws ec2 modify-instance-metadata-options --region ap-southeast-1 \
    --instance-id i-00a580e4eda375a9e --http-tokens required --http-endpoint enabled
  ```
- [ ] Promote `uat → main` → prod deploys with `HttpTokens=required` and Studio video upload works on first try.

## Follow-ups

- After this lands, revert UAT EC2 IMDS to `required` (closes the IMDSv1 SSRF surface).
- Reference this PR from deeprun-academy/tutor-config#13 (S3 CORS automation) and deeprun-academy/tutor-config#12 (regression-check gates).