### PR TITLE
fix: promote dev to uat (video upload S3 credentials)

### DIFF
--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -870,6 +870,14 @@ def videos_post(course, request):
 def storage_service_bucket():
     """
     Returns an S3 bucket for video upload.
+
+    Credentials resolution:
+      * Devstack path keeps legacy behaviour (explicit settings incl. security token).
+      * Production path prefers explicit `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` when set,
+        and otherwise falls back to the boto3 credential chain (env vars, shared config,
+        EC2 IAM role via IMDSv2). The legacy `boto` library used here cannot speak IMDSv2
+        on its own, which broke Studio video uploads on EC2 instances running with the
+        AWS-default `HttpTokens=required` — see deeprun-academy/openedx-platform#30.
     """
     if ENABLE_DEVSTACK_VIDEO_UPLOADS.is_enabled():
         params = {
@@ -879,10 +887,30 @@ def storage_service_bucket():
 
         }
     else:
+        access_key = settings.AWS_ACCESS_KEY_ID
+        secret_key = settings.AWS_SECRET_ACCESS_KEY
+        security_token = None
+        if not access_key or not secret_key:
+            # Fall back to the boto3 credential chain (env, shared config, IAM role via IMDSv2).
+            import boto3
+            frozen = None
+            creds = boto3.Session().get_credentials()
+            if creds is not None:
+                frozen = creds.get_frozen_credentials()
+            if frozen is None or not frozen.access_key or not frozen.secret_key:
+                raise RuntimeError(
+                    "No AWS credentials available for video upload bucket: set "
+                    "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or attach an IAM instance role."
+                )
+            access_key = frozen.access_key
+            secret_key = frozen.secret_key
+            security_token = frozen.token
         params = {
-            'aws_access_key_id': settings.AWS_ACCESS_KEY_ID,
-            'aws_secret_access_key': settings.AWS_SECRET_ACCESS_KEY
+            'aws_access_key_id': access_key,
+            'aws_secret_access_key': secret_key,
         }
+        if security_token:
+            params['security_token'] = security_token
 
     conn = S3Connection(**params)
 

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -1666,6 +1666,44 @@ class GetStorageBucketTestCase(TestCase):
         self.assertIn("https://vem_test_bucket.s3.amazonaws.com:443/test_root/", upload_url)
         self.assertIn(edx_video_id, upload_url)
 
+    @override_settings(AWS_ACCESS_KEY_ID=None, AWS_SECRET_ACCESS_KEY=None)
+    @override_settings(VIDEO_UPLOAD_PIPELINE={
+        "VEM_S3_BUCKET": "vem_test_bucket", "BUCKET": "test_bucket", "ROOT_PATH": "test_root"
+    })
+    def test_storage_bucket_falls_back_to_boto3_credentials(self):
+        """When explicit AWS keys are unset (IAM role deploy), credentials come from
+        the boto3 chain (env vars, shared config, EC2 IMDSv2 instance role)."""
+        frozen = Mock(access_key='boto3_key', secret_key='boto3_secret', token='boto3_token')
+        session = Mock()
+        session.get_credentials.return_value.get_frozen_credentials.return_value = frozen
+
+        with patch('boto3.Session', return_value=session) as session_cls, \
+                patch(
+                    'cms.djangoapps.contentstore.video_storage_handlers.S3Connection'
+                ) as s3_conn_cls:
+            storage_service_bucket()
+
+        session_cls.assert_called_once_with()
+        s3_conn_cls.assert_called_once_with(
+            aws_access_key_id='boto3_key',
+            aws_secret_access_key='boto3_secret',
+            security_token='boto3_token',
+        )
+
+    @override_settings(AWS_ACCESS_KEY_ID=None, AWS_SECRET_ACCESS_KEY=None)
+    @override_settings(VIDEO_UPLOAD_PIPELINE={
+        "VEM_S3_BUCKET": "vem_test_bucket", "BUCKET": "test_bucket", "ROOT_PATH": "test_root"
+    })
+    def test_storage_bucket_raises_when_no_credentials_available(self):
+        """Fail loudly rather than passing None into boto when the IAM role is missing."""
+        session = Mock()
+        session.get_credentials.return_value = None
+
+        with patch('boto3.Session', return_value=session), \
+                patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection'):
+            with self.assertRaisesRegex(RuntimeError, 'No AWS credentials available'):
+                storage_service_bucket()
+
 
 class CourseYoutubeEdxVideoIds(ModuleStoreTestCase):
     """


### PR DESCRIPTION
## Summary
- Promote `dev` → `uat` with video upload S3 credential fix
- Enhances S3 credential handling in `video_storage_handlers.py` to work with EC2 IAM role

## Commits
- #31 fix(video_storage): enhance S3 credential handling for video uploads

## Changes
- `cms/djangoapps/contentstore/video_storage_handlers.py` — credential resolution
- `cms/djangoapps/contentstore/views/tests/test_videos.py` — tests added

## Test plan
- [ ] Upload a video in Studio on uat, confirm S3 PUT succeeds without hardcoded keys
- [ ] Confirm existing video list / playback still works